### PR TITLE
Print message when waiting for user input

### DIFF
--- a/cmd/core/input/input.go
+++ b/cmd/core/input/input.go
@@ -72,6 +72,7 @@ func parse(input io.Reader, transformer Transformer) []interface{} {
 
 func open(filename string) (*os.File, error) {
 	if len(filename) == 0 {
+		log.Errorf("Reading input lines until EOF:\n")
 		return os.Stdin, nil
 	}
 	return os.Open(filename)


### PR DESCRIPTION
Many users find it confusing that __fbender__ doesn't do anything when they type the test command without specifying an input file. Printing message should help them when starting the journey with __fbender__.