### PR TITLE
Add protocol support for DNS

### DIFF
--- a/cmd/dns/cmd.go
+++ b/cmd/dns/cmd.go
@@ -38,6 +38,5 @@ var Command = core.NewTestCommand(template, params)
 
 func init() {
 	Command.PersistentFlags().BoolP("randomize", "r", false, "randomize queries with timestamp and a random hex")
-	Command.PersistentFlags().StringP(
-		"protocol", "p", "udp", "protocol to use for DNS queries. Can be tcp or udp (default udp)")
+	Command.PersistentFlags().StringP("protocol", "p", "udp", "protocol to use for DNS queries. Can be tcp or udp")
 }

--- a/cmd/dns/cmd.go
+++ b/cmd/dns/cmd.go
@@ -38,4 +38,6 @@ var Command = core.NewTestCommand(template, params)
 
 func init() {
 	Command.PersistentFlags().BoolP("randomize", "r", false, "randomize queries with timestamp and a random hex")
+	Command.PersistentFlags().StringP(
+		"protocol", "p", "udp", "protocol to use for DNS queries. Can be tcp or udp (default udp)")
 }

--- a/cmd/dns/dns.go
+++ b/cmd/dns/dns.go
@@ -31,13 +31,21 @@ func params(cmd *cobra.Command, o *options.Options) (*runner.Params, error) {
 	if err != nil {
 		return nil, err
 	}
+	protocol, err := cmd.Flags().GetString("protocol")
+	if err != nil {
+		return nil, err
+	}
+	if protocol != "tcp" && protocol != "udp" {
+		return nil, fmt.Errorf("unknown protocol (%s), expecting one of 'tcp' or 'udp'", protocol)
+	}
 	r, err := input.NewRequestGenerator(o.Input, inputTransformer, getModifiers(randomize)...)
 	if err != nil {
 		return nil, err
 	}
 	t := &tester.Tester{
-		Target:  utils.WithDefaultPort(o.Target, DefaultServerPort),
-		Timeout: o.Timeout,
+		Target:   utils.WithDefaultPort(o.Target, DefaultServerPort),
+		Timeout:  o.Timeout,
+		Protocol: protocol,
 	}
 	return &runner.Params{Tester: t, RequestGenerator: r}, nil
 }

--- a/docs/PROTOCOLS.md
+++ b/docs/PROTOCOLS.md
@@ -55,9 +55,9 @@ fbender dhcpv6 throughput constraints \
 
 ### Custom Flags
 
-In addition to other standard flags  allows to prefix all queries with randomly
-generated values to avoid cached responses. When (`-r, --randomize` ) the
-queries will be prefixed as follows (the _QType_ remains unchanged)
+In addition to other standard flags DNS allows you prefix all queries with 
+randomly generated values to avoid cached responses. When (`-r, --randomize` ) 
+the queries will be prefixed as follows (the _QType_ remains unchanged)
 
 ```
 time.hex.domain
@@ -83,6 +83,9 @@ another.example.com A
 yet.another.example.com MX
 example.com TXT
 ```
+
+Also, DNS can be load tested over tcp, rather than just the standard udp
+interface, by specifying (`-p, --protocol tcp`).
 
 ### Examples
 

--- a/tester/dns/tester.go
+++ b/tester/dns/tester.go
@@ -17,11 +17,12 @@ import (
 	protocol "github.com/pinterest/bender/dns"
 )
 
-// Tester is a load tester for DHCPv6
+// Tester is a load tester for DNS
 type Tester struct {
-	Target  string
-	Timeout time.Duration
-	client  *dns.Client
+	Target   string
+	Timeout  time.Duration
+	Protocol string
+	client   *dns.Client
 }
 
 // Before is called before the first test
@@ -30,6 +31,7 @@ func (t *Tester) Before(options interface{}) error {
 		ReadTimeout:  t.Timeout,
 		DialTimeout:  t.Timeout,
 		WriteTimeout: t.Timeout,
+		Net:          t.Protocol,
 	}
 	return nil
 }


### PR DESCRIPTION
Allow testing of DNS using UDP or TCP.
Default to UDP (current/normal behavior)