### PR TITLE
Remake autocompletion

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -76,11 +76,7 @@ other output. Available levels (both numbers and literals are accepted):
   fbender http concurrency constraints -t $TARGET 20 -c "MAX(errors)<5"
   fbender dhcpv6 throughput constraints -t $TARGET 50 -c "MIN(latency)<20"
   fbender dns throughput constraints -t $TARGET 40 -c -g ^10 "MAX(errors)<5"`,
-	BashCompletionFunction: `__fbender_handle_constraint_flag()
-	{
-		COMPREPLY=($(compgen -W "uniform exponential" -- "${cur}"))
-	}
-
+	BashCompletionFunction: `
 	__fbender_handle_loglevel_flag()
 	{
 		COMPREPLY=($(compgen -W "panic fatal error warning info debug" -- "${cur}"))
@@ -127,7 +123,7 @@ func initExecutionFlags() {
 	distribution := flags.NewDefaultDistribution()
 	distributionChoices := flags.ChoicesString(flags.DistributionChoices())
 	Command.PersistentFlags().VarP(distribution, "dist", "D", fmt.Sprintf("requests distribution %s", distributionChoices))
-	if err := cobra.MarkFlagCustom(Command.PersistentFlags(), "dist", "__fbender_handle_constraint_flag"); err != nil {
+	if err := flags.BashCompletionDistribution(Command, Command.PersistentFlags(), "dist"); err != nil {
 		panic(err)
 	}
 	// Other settings

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/facebookincubator/fbender/cmd/core"
 	"github.com/facebookincubator/fbender/cmd/dhcpv4"
 	"github.com/facebookincubator/fbender/cmd/dhcpv6"
 	"github.com/facebookincubator/fbender/cmd/dns"
@@ -148,6 +149,9 @@ func init() {
 		}
 	}
 	Command.AddCommand(completionCmd)
+	// Start post init functions
+	core.PostInit <- struct{}{}
+	core.PostInitWaitGroup.Wait()
 }
 
 // Execute runs the Command

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -76,16 +76,6 @@ other output. Available levels (both numbers and literals are accepted):
   fbender http concurrency constraints -t $TARGET 20 -c "MAX(errors)<5"
   fbender dhcpv6 throughput constraints -t $TARGET 50 -c "MIN(latency)<20"
   fbender dns throughput constraints -t $TARGET 40 -c -g ^10 "MAX(errors)<5"`,
-	BashCompletionFunction: `
-	__fbender_handle_loglevel_flag()
-	{
-		COMPREPLY=($(compgen -W "panic fatal error warning info debug" -- "${cur}"))
-	}
-
-	__fbender_handle_logformat_flag()
-	{
-		COMPREPLY=($(compgen -W "text json" -- "${cur}"))
-	}`,
 }
 
 func initIOFlags() {
@@ -104,14 +94,14 @@ func initIOFlags() {
 	logLevel := &flags.LogLevel{Logger: logrus.StandardLogger()}
 	logLevelChoices := flags.ChoicesString(flags.LogLevelChoices())
 	Command.PersistentFlags().VarP(logLevel, "verbosity", "v", fmt.Sprintf("verbosity level %s", logLevelChoices))
-	if err := cobra.MarkFlagCustom(Command.PersistentFlags(), "verbosity", "__fbender_handle_loglevel_flag"); err != nil {
+	if err := flags.BashCompletionLogLevel(Command, Command.PersistentFlags(), "verbosity"); err != nil {
 		panic(err)
 	}
 	// Log format
 	logFormat := &flags.LogFormat{Logger: logrus.StandardLogger(), Format: "json"}
 	logFormatChoices := flags.ChoicesString(flags.LogFormatChoices())
 	Command.PersistentFlags().VarP(logFormat, "format", "f", fmt.Sprintf("output format %s", logFormatChoices))
-	if err := cobra.MarkFlagCustom(Command.PersistentFlags(), "format", "__fbender_handle_logformat_flag"); err != nil {
+	if err := flags.BashCompletionLogFormat(Command, Command.PersistentFlags(), "format"); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/core/extract.go
+++ b/cmd/core/extract.go
@@ -1,3 +1,11 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 package core
 
 import (

--- a/cmd/core/sync.go
+++ b/cmd/core/sync.go
@@ -1,0 +1,19 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package core
+
+import (
+	"sync"
+)
+
+// Variables used for post initialization functions
+var (
+	PostInit          = make(chan struct{}, 1)
+	PostInitWaitGroup = &sync.WaitGroup{}
+)

--- a/flags/distribution.go
+++ b/flags/distribution.go
@@ -13,7 +13,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/facebookincubator/fbender/utils"
 	"github.com/pinterest/bender"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -103,4 +105,22 @@ func GetDistributionValue(v pflag.Value) (DistributionGenerator, error) {
 		return distribution.Get(), nil
 	}
 	return nil, fmt.Errorf("trying to get distribution value of flag of type %s", v.Type())
+}
+
+// Bash completion function constants
+const (
+	fnameDistribution = "__fbender_handle_distribution_flag"
+	fbodyDistribution = `COMPREPLY=($(compgen -W "uniform exponential" -- "${cur}"))`
+)
+
+// BashCompletionProtocol adds bash completion to a distribution flag
+func BashCompletionDistribution(cmd *cobra.Command, f *pflag.FlagSet, name string) error {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("flag %s accessed but not defined", name)
+	}
+	if _, ok := flag.Value.(*Distribution); !ok {
+		return fmt.Errorf("trying to autocomplete distribution on flag of type %s", flag.Value.Type())
+	}
+	return utils.BashCompletion(cmd, f, name, fnameDistribution, fbodyDistribution)
 }

--- a/flags/distribution_test.go
+++ b/flags/distribution_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/pinterest/bender"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -145,4 +146,23 @@ func TestGetDistributionValue(t *testing.T) {
 	require.NotNil(t, flag)
 	_, err = flags.GetDistributionValue(flag.Value)
 	assert.EqualError(t, err, "trying to get distribution value of flag of type int")
+}
+
+func TestBashCompletionDistribution(t *testing.T) {
+	c := &cobra.Command{}
+	d := flags.NewDefaultDistribution()
+	// Check no error when applied to distribution flag
+	f := c.Flags().VarPF(d, "distribution", "d", "set distribution")
+	err := flags.BashCompletionDistribution(c, c.Flags(), "distribution")
+	require.NoError(t, err)
+	require.Contains(t, f.Annotations, "cobra_annotation_bash_completion_custom")
+	assert.Equal(t, []string{"__fbender_handle_distribution_flag"},
+		f.Annotations["cobra_annotation_bash_completion_custom"])
+	// Check error when flag is not defined
+	err = flags.BashCompletionDistribution(c, c.Flags(), "nonexistent")
+	assert.EqualError(t, err, "flag nonexistent accessed but not defined")
+	// Check error when flag is not a distribution
+	c.Flags().Int("myint", 0, "set myint")
+	err = flags.BashCompletionDistribution(c, c.Flags(), "myint")
+	assert.EqualError(t, err, "trying to autocomplete distribution on flag of type int")
 }

--- a/flags/log.go
+++ b/flags/log.go
@@ -13,8 +13,13 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/facebookincubator/fbender/utils"
 )
 
 // LogLevel represents a log level flag value
@@ -53,6 +58,25 @@ func (l *LogLevel) Set(value string) error {
 // Type returns a log level value type
 func (l *LogLevel) Type() string {
 	return "level"
+}
+
+// Bash completion function constants
+const (
+	fnameLogLevel = "__fbender_handle_loglevel_flag"
+	fbodyLogLevel = `COMPREPLY=($(compgen -W "%s" -- "${cur}"))`
+)
+
+// BashCompletionLogLevel adds bash completion to a distribution flag
+func BashCompletionLogLevel(cmd *cobra.Command, f *pflag.FlagSet, name string) error {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("flag %s accessed but not defined", name)
+	}
+	if _, ok := flag.Value.(*LogLevel); !ok {
+		return fmt.Errorf("trying to autocomplete level on flag of type %s", flag.Value.Type())
+	}
+	fbody := fmt.Sprintf(fbodyLogLevel, strings.Join(LogLevelChoices(), " "))
+	return utils.BashCompletion(cmd, f, name, fnameLogLevel, fbody)
 }
 
 // LogFormat represents a log format flag value
@@ -100,6 +124,25 @@ func (l *LogFormat) Set(value string) error {
 // Type returns a log format value type
 func (l *LogFormat) Type() string {
 	return "format"
+}
+
+// Bash completion function constants
+const (
+	fnameLogFormat = "__fbender_handle_logformat_flag"
+	fbodyLogFormat = `COMPREPLY=($(compgen -W "%s" -- "${cur}"))`
+)
+
+// BashCompletionLogFormat adds bash completion to a distribution flag
+func BashCompletionLogFormat(cmd *cobra.Command, f *pflag.FlagSet, name string) error {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("flag %s accessed but not defined", name)
+	}
+	if _, ok := flag.Value.(*LogFormat); !ok {
+		return fmt.Errorf("trying to autocomplete format on flag of type %s", flag.Value.Type())
+	}
+	fbody := fmt.Sprintf(fbodyLogFormat, strings.Join(LogFormatChoices(), " "))
+	return utils.BashCompletion(cmd, f, name, fnameLogFormat, fbody)
 }
 
 // LogOutput represents a log output flag value

--- a/utils/completion.go
+++ b/utils/completion.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const template = `
+%s() {
+	%s
+}`
+
+// BashCompletion annotates the flag with completion function and registers the
+// completion function in the root command if it hasn't been added already.
+func BashCompletion(cmd *cobra.Command, flags *pflag.FlagSet, flag string, fname, fbody string) error {
+	if !strings.Contains(cmd.Root().BashCompletionFunction, fname) {
+		cmd.Root().BashCompletionFunction += fmt.Sprintf(template, fname, fbody)
+	}
+	return cobra.MarkFlagCustom(flags, flag, fname)
+}

--- a/utils/completion_test.go
+++ b/utils/completion_test.go
@@ -1,0 +1,44 @@
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/facebookincubator/fbender/utils"
+)
+
+func TestBashCompletion(t *testing.T) {
+	const (
+		fname = "__fbender_test_handle_flag"
+		fbody = `COMPREPLY=($(compgen -W "42 24" -- "${cur}"))`
+	)
+
+	c := &cobra.Command{}
+	c.Flags().Int("myint", 0, "set myint")
+
+	// Check if the completion function is appended
+	err := utils.BashCompletion(c, c.Flags(), "myint", fname, fbody)
+	require.NoError(t, err)
+	assert.Contains(t, c.BashCompletionFunction, fname)
+	assert.Equal(t, `
+__fbender_test_handle_flag() {
+	COMPREPLY=($(compgen -W "42 24" -- "${cur}"))
+}`, c.BashCompletionFunction)
+
+	// Check if the flag annotation has been added
+	f := c.Flags().Lookup("myint")
+	require.NotNil(t, f)
+	require.Contains(t, f.Annotations, "cobra_annotation_bash_completion_custom")
+	assert.Equal(t, []string{fname}, f.Annotations["cobra_annotation_bash_completion_custom"])
+
+	// Check if the completion function is appended only once
+	err = utils.BashCompletion(c, c.Flags(), "myint", fname, fbody)
+	require.NoError(t, err)
+	assert.Contains(t, c.BashCompletionFunction, fname)
+	count := strings.Count(c.BashCompletionFunction, fname)
+	assert.Equal(t, 1, count, "Completion function should be added only once")
+}


### PR DESCRIPTION
While making the DNS `--protocol` flag a custom cobra flag to add autocompletion and validation I've remade the whole autocompletion, so it's cleaner and easier scalable. The next PR will add the protocol flag, I want to keep this one smaller.

### The problem
All bash functions were previously inlined in the main command `BashCompletionFunc` field. For all possible completion functions we wanted to use they had to be manually added to the string in the `Command`. It had no flexibility when adding new flags. 

### The solution
Introduced `postinit` functions which are called after all `init` functions are completed. In particular they are deferred until the `init` function of `fbender/cmd/cmd.go` finishes. That way we can be sure that the command tree is completely built and `cmd.Root()` on the commands can be accessed. This also allows to check whether a proper completion function is used for a flag (for example assert on using `loglevel` completion on non-loglevel flag).

### Test plan
Build to ensure a clean bash
```sh
$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o fbender
$ docker build . -t fbender
```

With the following docker image

```docker
FROM alpine:latest
ADD fbender /go/bin/fbender
RUN apk update && apk upgrade && apk add bash bash-completion
ENV PATH /go/bin:$PATH
ENTRYPOINT ["/go/bin/fbender"]
```

After each line a tab was pressed twice to show the suggestions
```
$ docker run --rm -it --entrypoint /bin/bash fbender
bash-4.4# fbender dns throughput fixed -D
exponential  uniform
bash-4.4# fbender dns throughput fixed -D exponential -v
debug    error    fatal    info     panic    warning
bash-4.4# fbender dns throughput fixed -D exponential -v debug -f
json  text
bash-4.4# fbender dns throughput fixed -D exponential -v debug -f json -p
tcp  udp
bash-4.4# fbender dns throughput fixed -D exponential -v debug -f json -p tcp
```