### PR TITLE
DNS custom flags completion

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -135,9 +135,7 @@ func init() {
 		}
 	}
 	Command.AddCommand(completionCmd)
-	// Start post init functions
-	core.PostInit <- struct{}{}
-	core.PostInitWaitGroup.Wait()
+	core.StartPostInit()
 }
 
 // Execute runs the Command

--- a/cmd/dns/cmd.go
+++ b/cmd/dns/cmd.go
@@ -38,5 +38,13 @@ var Command = core.NewTestCommand(template, params)
 
 func init() {
 	Command.PersistentFlags().BoolP("randomize", "r", false, "randomize queries with timestamp and a random hex")
-	Command.PersistentFlags().StringP("protocol", "p", "udp", "protocol to use for DNS queries. Can be tcp or udp")
+	core.DeferPostInit(postinit)
+}
+
+func postinit() {
+	protocol := NewProtocolValue()
+	Command.PersistentFlags().VarP(protocol, "protocol", "p", "protocol used for DNS queries (udp|tcp)")
+	if err := BashCompletionProtocol(Command, Command.PersistentFlags(), "protocol"); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/dns/dns.go
+++ b/cmd/dns/dns.go
@@ -31,12 +31,9 @@ func params(cmd *cobra.Command, o *options.Options) (*runner.Params, error) {
 	if err != nil {
 		return nil, err
 	}
-	protocol, err := cmd.Flags().GetString("protocol")
+	protocol, err := GetProtocol(cmd.Flags(), "protocol")
 	if err != nil {
 		return nil, err
-	}
-	if protocol != "tcp" && protocol != "udp" {
-		return nil, fmt.Errorf("unknown protocol (%s), expecting one of 'tcp' or 'udp'", protocol)
 	}
 	r, err := input.NewRequestGenerator(o.Input, inputTransformer, getModifiers(randomize)...)
 	if err != nil {

--- a/cmd/dns/flags.go
+++ b/cmd/dns/flags.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package dns
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/facebookincubator/fbender/utils"
+)
+
+// protocols is a set of available protocols
+var protocols = map[string]struct{}{
+	"udp": {},
+	"tcp": {},
+}
+
+type protocolValue struct {
+	value string
+}
+
+func NewProtocolValue() pflag.Value {
+	return &protocolValue{value: "udp"}
+}
+
+func (s *protocolValue) Set(value string) error {
+	if _, ok := protocols[value]; ok {
+		s.value = value
+		return nil
+	}
+	return fmt.Errorf("unknown protocol %q, want: \"udp\" or \"tcp\"", value)
+}
+
+func (s *protocolValue) Type() string {
+	return "protocol"
+}
+
+func (s *protocolValue) String() string {
+	return s.value
+}
+
+// GetProtocol returns a protocol from a pflag set
+func GetProtocol(f *pflag.FlagSet, name string) (string, error) {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return "", fmt.Errorf("flag %s accessed but not defined", name)
+	}
+	return GetProtocolValue(flag.Value)
+}
+
+// GetProtocolValue returns a protocol from a pflag value
+func GetProtocolValue(v pflag.Value) (string, error) {
+	if protocol, ok := v.(*protocolValue); ok {
+		return protocol.value, nil
+	}
+	return "", fmt.Errorf("trying to get protocol value of flag of type %s", v.Type())
+}
+
+// Bash completion function constants
+const (
+	fname = "__fbender_handle_dns_protocol_flag"
+	fbody = `COMPREPLY=($(compgen -W "udp tcp" -- "${cur}"))`
+)
+
+// BashCompletionProtocol adds bash completion to a protocol flag
+func BashCompletionProtocol(cmd *cobra.Command, flags *pflag.FlagSet, name string) error {
+	return utils.BashCompletion(cmd, flags, name, fname, fbody)
+}

--- a/cmd/dns/flags_test.go
+++ b/cmd/dns/flags_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package dns_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/suite"
+
+	flags "github.com/facebookincubator/fbender/cmd/dns"
+)
+
+type ProtocolValueTestSuite struct {
+	suite.Suite
+	value pflag.Value
+}
+
+func (s *ProtocolValueTestSuite) SetupTest() {
+	s.value = flags.NewProtocolValue()
+	s.Require().NotNil(s.value)
+}
+
+func (s *ProtocolValueTestSuite) TestSet_NoErrors() {
+	err := s.value.Set("udp")
+	s.Require().NoError(err)
+	v, err := flags.GetProtocolValue(s.value)
+	s.Require().NoError(err)
+	s.Assert().Equal("udp", v)
+
+	err = s.value.Set("tcp")
+	s.Require().NoError(err)
+	v, err = flags.GetProtocolValue(s.value)
+	s.Require().NoError(err)
+	s.Assert().Equal("tcp", v)
+}
+
+func (s *ProtocolValueTestSuite) TestSet_Errors() {
+	// Save original flag value
+	o, err := flags.GetProtocolValue(s.value)
+	s.Require().NoError(err)
+	// Try invalid value
+	err = s.value.Set("unknown")
+	s.Assert().EqualError(err, "unknown protocol \"unknown\", want: \"udp\" or \"tcp\"")
+	// The value shouldn't change
+	v, err := flags.GetProtocolValue(s.value)
+	s.Require().NoError(err)
+	s.Assert().Equal(o, v)
+}
+
+func (s *ProtocolValueTestSuite) TestType() {
+	s.Assert().Equal("protocol", s.value.Type())
+}
+
+func (s *ProtocolValueTestSuite) TestGetProtocol() {
+	f := pflag.NewFlagSet("Test FlagSet", pflag.ExitOnError)
+	f.Var(s.value, "protocol", "set protocol")
+
+	err := s.value.Set("tcp")
+	s.Require().NoError(err)
+
+	v, err := flags.GetProtocol(f, "protocol")
+	s.Require().NoError(err)
+	s.Assert().Equal("tcp", v)
+
+	// Check error when flag does not exist
+	_, err = flags.GetProtocol(f, "nonexistent")
+	s.Assert().EqualError(err, "flag nonexistent accessed but not defined")
+
+	// Check error when value is of different type
+	f.Int("myint", 0, "set myint")
+	_, err = flags.GetProtocol(f, "myint")
+	s.Assert().EqualError(err, "trying to get protocol value of flag of type int")
+}
+
+func (s *ProtocolValueTestSuite) TestGetProtocolValue() {
+	err := s.value.Set("tcp")
+	s.Require().NoError(err)
+
+	v, err := flags.GetProtocolValue(s.value)
+	s.Require().NoError(err)
+	s.Assert().Equal("tcp", v)
+
+	// Check error when value is of different type
+	f := pflag.NewFlagSet("Test FlagSet", pflag.ExitOnError)
+	f.Int("myint", 0, "set myint")
+	flag := f.Lookup("myint")
+	s.Require().NotNil(flag)
+	_, err = flags.GetProtocolValue(flag.Value)
+	s.Assert().EqualError(err, "trying to get protocol value of flag of type int")
+}
+
+func (s *ProtocolValueTestSuite) TestBashCompletionProtocol() {
+	c := &cobra.Command{}
+	f := c.Flags().VarPF(s.value, "protocol", "p", "set protocol")
+	// Check if the complete function is appended
+	err := flags.BashCompletionProtocol(c, c.Flags(), "protocol")
+	s.Require().NoError(err)
+	s.Assert().Contains(c.BashCompletionFunction, "__fbender_handle_dns_protocol_flag")
+	// Check if the flag has the bash
+	s.Require().Contains(f.Annotations, "cobra_annotation_bash_completion_custom")
+	s.Assert().Equal([]string{"__fbender_handle_dns_protocol_flag"},
+		f.Annotations["cobra_annotation_bash_completion_custom"])
+	// Check if the function is appended only once
+	err = flags.BashCompletionProtocol(c, c.Flags(), "protocol")
+	s.Require().NoError(err)
+	count := strings.Count(c.BashCompletionFunction, "__fbender_handle_dns_protocol_flag")
+	s.Assert().Equal(1, count, "Completion function should be added only once")
+}
+
+func TestProtocolValueTestSuite(t *testing.T) {
+	suite.Run(t, new(ProtocolValueTestSuite))
+}


### PR DESCRIPTION
Custom flag for DNS protocol, this can be nicely tested and allows for autocompletion.

### Test plan
Build to ensure a clean bash

```sh
$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o fbender
$ docker build . -t fbender
```

With the following docker image

```docker
FROM alpine:latest
ADD fbender /go/bin/fbender
RUN apk update && apk upgrade && apk add bash bash-completion
ENV PATH /go/bin:$PATH
ENTRYPOINT ["/go/bin/fbender"]
```

```sh
$ docker run --rm -it --entrypoint /bin/bash fbender
bash-4.4# . /etc/profile.d/bash_completion.sh
bash-4.4# . <(fbender co b)
bash-4.4# fbender dns throughput fixed -p
tcp  udp
bash-4.4# fbender dns throughput fixed -p udp -t 8.8.8.8 -d 5s 10 -o/dev/null
Reading input lines until EOF:
google.com AAAA
Cleaning up the memory... Done.
Preparing the test... Done.
Running test: 10
Percentiles (1ms):
 Min:     16
 Median:  28
 90th:    42
 99th:    45
 99.9th:  79
 99.99th: 79
 Max:     79
Stats:
 Average (1ms): 31.180000
 Total requests: 50
 Elapsed Time (sec): 5.0424
 Average QPS: 9.92
 Errors: 0
 Percent errors: 0.00
bash-4.4#
```
