### PR TITLE
Add golint check and fix lint warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,6 @@ jobs:
           name: Lint
           command: |
             curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.10.2
+            go get -u golang.org/x/lint/golint
             golangci-lint run
+            golint -set_exit_status

--- a/cmd/dns/flags.go
+++ b/cmd/dns/flags.go
@@ -27,6 +27,7 @@ type protocolValue struct {
 	value string
 }
 
+// NewProtocolValue returns new Protocol flag with a default value.
 func NewProtocolValue() pflag.Value {
 	return &protocolValue{value: "udp"}
 }

--- a/flags/distribution.go
+++ b/flags/distribution.go
@@ -113,7 +113,7 @@ const (
 	fbodyDistribution = `COMPREPLY=($(compgen -W "uniform exponential" -- "${cur}"))`
 )
 
-// BashCompletionProtocol adds bash completion to a distribution flag
+// BashCompletionDistribution adds bash completion to a distribution flag
 func BashCompletionDistribution(cmd *cobra.Command, f *pflag.FlagSet, name string) error {
 	flag := f.Lookup(name)
 	if flag == nil {


### PR DESCRIPTION
Some golint issues were found on the [go report](https://goreportcard.com/report/github.com/facebookincubator/fbender#golint). Fixed it and added a `golint` check to the circleci in addition to the other linter.